### PR TITLE
Fix #79: M2 not reporting new work offsets.

### DIFF
--- a/firmware/tinyg/canonical_machine.c
+++ b/firmware/tinyg/canonical_machine.c
@@ -729,6 +729,7 @@ static void _exec_offset(float *value, float *flag)
 		offsets[axis] = cm.offset[coord_system][axis] + (cm.gmx.origin_offset[axis] * cm.gmx.origin_offset_enable);
 	}
 	mp_set_runtime_work_offset(offsets);
+	cm_set_work_offsets(&cm.gm);
 }
 
 /*


### PR DESCRIPTION
This CL fixes incorrect M2 behavior that does not reset work offsets properly. Please, find more details in the [bug description](https://github.com/synthetos/TinyG/issues/79).

Without the fix:

```
> {"sr":""}
{"r":{"sr":{"mpox":0.000,"mpoy":0.000,"mpoz":0.000,"mpoa":0.000,"ofsx":0.000,"ofsy":0.000,"ofsz":0.000,"ofsa":0.000,"unit":1,"stat":1,"coor":2,"momo":4,"dist":0,"home":0,"hold":0,"macs":1,"cycs":0,"mots":0,"plan":0,"prbe":0}},"f":[1,0,10,2205]}

> G0 X10
{"r":{},"f":[1,0,7,4400]}
{"sr":{"mpox":0.000,"stat":5,"momo":0,"macs":5,"cycs":1,"mots":1}}
{"qr":27}
{"sr":{"mpox":3.830}}
{"sr":{"mpox":9.502}}
{"sr":{"mpox":10.000,"stat":3,"macs":3,"cycs":0,"mots":0}}
{"qr":28}

> G92 X0
{"r":{},"f":[1,0,7,4400]}
{"sr":{"ofsx":10.000}}
{"qr":28}

> G0 X10
{"r":{},"f":[1,0,7,4400]}
{"sr":{"mpox":10.000,"stat":5,"macs":5,"cycs":1,"mots":1}}
{"qr":27}
{"sr":{"mpox":13.707}}
{"sr":{"mpox":19.432}}
{"sr":{"mpox":20.000,"stat":3,"macs":3,"cycs":0,"mots":0}}
{"qr":28}

> M2
{"r":{},"f":[1,0,3,4396]}
{"sr":{"stat":4,"momo":4,"macs":4}}
{"qr":28}
```

With the fix:

```
> {"sr":""}
{"r":{"sr":{"mpox":0.000,"mpoy":0.000,"mpoz":0.000,"mpoa":0.000,"ofsx":0.000,"ofsy":0.000,"ofsz":0.000,"ofsa":0.000,"unit":1,"stat":1,"coor":2,"momo":4,"dist":0,"home":0,"hold":0,"macs":1,"cycs":0,"mots":0,"plan":0,"prbe":0}},"f":[1,0,10,2205]}

> G0 X10
{"r":{},"f":[1,0,7,4400]}
{"sr":{"mpox":0.000,"stat":5,"momo":0,"macs":5,"cycs":1,"mots":1}}
{"qr":27}
{"sr":{"mpox":3.830}}
{"sr":{"mpox":9.502}}
{"sr":{"mpox":10.000,"stat":3,"macs":3,"cycs":0,"mots":0}}
{"qr":28}

> G92 X0
{"r":{},"f":[1,0,7,4400]}
{"sr":{"ofsx":10.000}}
{"qr":28}

> G0 X10
{"r":{},"f":[1,0,7,4400]}
{"sr":{"mpox":10.000,"stat":5,"macs":5,"cycs":1,"mots":1}}
{"qr":27}
{"sr":{"mpox":13.707}}
{"sr":{"mpox":19.432}}
{"sr":{"mpox":20.000,"stat":3,"macs":3,"cycs":0,"mots":0}}
{"qr":28}

> M2
{"r":{},"f":[1,0,3,4396]}
{"sr":{"ofsx":0.000,"stat":4,"momo":4,"macs":4}}
{"qr":28}
```

Given my limited knowledge of the code, this fix may be incorrect. Please, review it carefully.
