### PR TITLE
Initialize ACTIVE_MODEL earlier, before any use.

### DIFF
--- a/firmware/tinyg/canonical_machine.c
+++ b/firmware/tinyg/canonical_machine.c
@@ -580,6 +580,8 @@ void canonical_machine_init()
 
 	canonical_machine_init_assertions();
 
+	ACTIVE_MODEL = MODEL;			// setup initial Gcode model pointer
+
 	// set gcode defaults
 	cm_set_units_mode(cm.units_mode);
 	cm_set_coord_system(cm.coord_system);
@@ -597,8 +599,6 @@ void canonical_machine_init()
 	cm.feedhold_requested = false;
 	cm.queue_flush_requested = false;
 	cm.cycle_start_requested = false;
-
-	ACTIVE_MODEL = MODEL;			// setup initial Gcode model pointer
 
 	// signal that the machine is ready for action
 	cm.machine_state = MACHINE_READY;


### PR DESCRIPTION
This bug has been found during my effort to run TinyG firmware in the simulator environment, compiled by the host gcc. Currently, I have got to the point that TinyG starts and waits for the user input (see [sim3 branch](https://github.com/krasin/TinyG/tree/sim3); it's not yet ready for a merge).

The bug is a null pointer use. ACTIVE_MODEL is NULL, but cm_set_coord_system indirectly use it.

Here is the full stack trace:

```
krasin@krasin-gaz:~/src/github.com/krasin/TinyG/firmware/tinyg/sim$ gdb ./tinyg.elf 
GNU gdb (GDB) 7.6.2 (Debian 7.6.2-1)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /home/krasin/src/github.com/krasin/TinyG/firmware/tinyg/sim/tinyg.elf...done.
(gdb) r
Starting program: /home/krasin/src/github.com/krasin/TinyG/firmware/tinyg/sim/./tinyg.elf 
warning: Could not load shared library symbols for linux-vdso.so.1.
Do you need "set solib-search-path" or "set sysroot"?
{"r":{"fv":0.970,"fb":425.02,"hp":1,"hv":8,"id":"","msg":"Initializing configs to OMC OtherMill settings"},"f":[1,15,0,2991]}

Program received signal SIGSEGV, Segmentation fault.
cm_get_motion_mode (gcode_state=0x0) at ../canonical_machine.c:196
196     uint8_t cm_get_motion_mode(GCodeState_t *gcode_state) { return gcode_state->motion_mode;}
(gdb) bt
#0  cm_get_motion_mode (gcode_state=0x0) at ../canonical_machine.c:196
#1  0x00000000004067aa in qr_request_queue_report (buffers=buffers@entry=1 '\001') at ../report.c:447
#2  0x0000000000405fe4 in mp_commit_write_buffer (move_type=move_type@entry=3 '\003') at ../planner.c:445
#3  0x0000000000406051 in mp_queue_command (cm_exec=cm_exec@entry=0x40171b <_exec_offset>, value=value@entry=0x7fffffffe458, 
    flag=flag@entry=0x7fffffffe458) at ../planner.c:294
#4  0x0000000000401d5a in cm_set_coord_system (coord_system=<optimized out>) at ../canonical_machine.c:750
#5  0x0000000000401da0 in canonical_machine_init () at ../canonical_machine.c:589
#6  0x000000000040101a in _application_init () at ../main.c:142
#7  main () at ../main.c:165
(gdb) p gcode_state
$1 = (GCodeState_t *) 0x0
(gdb) up
#1  0x00000000004067aa in qr_request_queue_report (buffers=buffers@entry=1 '\001') at ../report.c:447
447             qr.motion_mode = cm_get_motion_mode(ACTIVE_MODEL);
(gdb) p cm.am
$2 = (struct GCodeState *) 0x0
```
