### PR TITLE
OMC TinyG bugfixes

### DIFF
--- a/firmware/tinyg.xcodeproj/project.pbxproj
+++ b/firmware/tinyg.xcodeproj/project.pbxproj
@@ -115,7 +115,6 @@
 		204C2FDD183D4B970058D2F2 /* plan_arc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = plan_arc.c; sourceTree = "<group>"; };
 		204C2FDE183D4B970058D2F2 /* plan_arc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = plan_arc.h; sourceTree = "<group>"; };
 		204C2FDF183D4B970058D2F2 /* plan_line.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = plan_line.c; sourceTree = "<group>"; };
-		204C2FE0183D4B970058D2F2 /* plan_line.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = plan_line.h; sourceTree = "<group>"; };
 		204C2FE1183D4B970058D2F2 /* planner.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = planner.c; sourceTree = "<group>"; };
 		204C2FE2183D4B970058D2F2 /* planner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = planner.h; sourceTree = "<group>"; };
 		204C2FE3183D4B970058D2F2 /* pwm.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pwm.c; sourceTree = "<group>"; };
@@ -192,6 +191,7 @@
 		204C302E183D4B970058D2F2 /* xmega_rtc.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xmega_rtc.c; sourceTree = "<group>"; };
 		204C302F183D4B970058D2F2 /* xmega_rtc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = xmega_rtc.h; sourceTree = "<group>"; };
 		204C3030183D4B970058D2F2 /* xmega_wdt.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = xmega_wdt.c; sourceTree = "<group>"; };
+		E21E39E9193F9C6300D483F8 /* plan_exec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = plan_exec.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -239,8 +239,8 @@
 				204C2FDC183D4B970058D2F2 /* network.h */,
 				204C2FDD183D4B970058D2F2 /* plan_arc.c */,
 				204C2FDE183D4B970058D2F2 /* plan_arc.h */,
+				E21E39E9193F9C6300D483F8 /* plan_exec.c */,
 				204C2FDF183D4B970058D2F2 /* plan_line.c */,
-				204C2FE0183D4B970058D2F2 /* plan_line.h */,
 				204C2FE1183D4B970058D2F2 /* planner.c */,
 				204C2FE2183D4B970058D2F2 /* planner.h */,
 				204C2FE3183D4B970058D2F2 /* pwm.c */,

--- a/firmware/tinyg/canonical_machine.c
+++ b/firmware/tinyg/canonical_machine.c
@@ -1248,6 +1248,8 @@ stat_t cm_queue_flush()
 	xio_reset_usb_rx_buffers();				// flush serial queues
 #endif
 	mp_flush_planner();						// flush planner queue
+	qr_request_queue_report(0);		// request a queue report, since we've changed the number of buffers available
+	printf("{\"rx\":%i}\n", xio_get_usb_rx_free());	// report updated free space in serial buffer
 
 	for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
 		cm_set_position(axis, mp_get_runtime_absolute_position(axis)); // set mm from mr

--- a/firmware/tinyg/canonical_machine.c
+++ b/firmware/tinyg/canonical_machine.c
@@ -1220,8 +1220,9 @@ stat_t cm_feedhold_sequencing_callback()
 		cm.feedhold_requested = false;
 	}
 	if (cm.queue_flush_requested == true) {
-		if ((cm.motion_state == MOTION_STOP) ||
-			((cm.motion_state == MOTION_HOLD) && (cm.hold_state == FEEDHOLD_HOLD))) {
+		if (((cm.motion_state == MOTION_STOP) ||
+			((cm.motion_state == MOTION_HOLD) && (cm.hold_state == FEEDHOLD_HOLD))) &&
+			!cm_get_runtime_busy()) {
 			cm.queue_flush_requested = false;
 			cm_queue_flush();
 		}
@@ -1241,12 +1242,8 @@ stat_t cm_feedhold_sequencing_callback()
 
 stat_t cm_queue_flush()
 {
-// NOTE: Although the following trap is technically correct it breaks OMC-style jogging, which
-//		 issues !%~ in rapid succession. So it's commented out for now. The correct way to handle
-//		 this in the tinyg code is to queue the % queue flush until after the feedhold stops,
-//		 and queue the ~ cycle start until after that.
-//	if (cm_get_runtime_busy() == true) { return (STAT_COMMAND_NOT_ACCEPTED);}	// can't flush during movement
-
+	if (cm_get_runtime_busy() == true) { return (STAT_COMMAND_NOT_ACCEPTED);}
+    
 #ifdef __AVR
 	xio_reset_usb_rx_buffers();				// flush serial queues
 #endif

--- a/firmware/tinyg/report.c
+++ b/firmware/tinyg/report.c
@@ -219,6 +219,7 @@ stat_t sr_set_status_report(nvObj_t *nv)
 			nv->value = nv->index;							// persist the index as the value
 			nv->index = sr_start + i;						// index of the SR persistence location
 			nv_persist(nv);
+			elements++;
 		} else {
 			return (STAT_INPUT_VALUE_UNSUPPORTED);
 		}

--- a/firmware/tinyg/switch.c
+++ b/firmware/tinyg/switch.c
@@ -125,9 +125,18 @@ static void _switch_isr_helper(uint8_t sw_num)
 void switch_rtc_callback(void)
 {
 	for (uint8_t i=0; i < NUM_SWITCHES; i++) {
-		if (sw.debounce[i] == SW_IDLE) continue;
+		if (sw.mode[i] == SW_MODE_DISABLED || sw.debounce[i] == SW_IDLE)
+			continue;
+
 		if (++sw.count[i] == SW_LOCKOUT_TICKS) {		// state is either lockout or deglitching
-			sw.debounce[i] = SW_IDLE; continue;
+			sw.debounce[i] = SW_IDLE;
+			// check if the state has changed while we were in lockout...
+			uint8_t old_state = sw.state[i];
+			if(old_state != read_switch(i)) {
+				sw.debounce[i] = SW_DEGLITCHING;
+				sw.count[i] = -SW_DEGLITCH_TICKS;
+			}
+			continue;
 		}
 		if (sw.count[i] == 0) {							// trigger point
 			sw.sw_num_thrown = i;						// record number of thrown switch
@@ -166,7 +175,7 @@ void reset_switches()
 {
 	for (uint8_t i=0; i < NUM_SWITCHES; i++) {
 		sw.debounce[i] = SW_IDLE;
-//		sw.count[i] = -SW_DEGLITCH_TICKS;
+		read_switch(i);
 	}
 	sw.limit_flag = false;
 }


### PR DESCRIPTION
This is the difference between our current top-of-tree and dev.  It has a bunch of small bugfixes that should be unobjectionable and a few things worth discussing:

On queue flush ("%"), we added {"qr":} and {"rx":} reports, since it affects both the # of buffers and # of serial bytes free.  Before, Otherplan was sending "%" and waiting for the qr and rx timers to expire, then manually requesting both values.

In the homing and probing cycle, at least for the old switch code, I changed the cycles to read out of sw.state[X] instead of actually polling (calling read_switch(X)).  This change goes hand in hand with the fix I made to switch.c, which fixed a race condition in the homing cycle that we exposed with some faulty wiring :).  I think as long as read_switch actually goes to the PIO peripheral, we should avoid calling it from cycles; if I recall, the G2 switch code has read_switch just returning the cached value and the polling happens in a different callback, so it's not an issue.

More minor things: a bad merge in sr_set_status_report that broke it, saving feed rate mode in cycles, making the probe cycle end function look more like jogging/homing end, updating the xcode project for added/deleted files, and adding the cm_get_runtime_busy gate to queue flush.