### PR TITLE
Fix incorrect units in prb when in inch mode

### DIFF
--- a/firmware/tinyg/canonical_machine.c
+++ b/firmware/tinyg/canonical_machine.c
@@ -742,7 +742,7 @@ stat_t cm_set_absolute_origin(float origin[], float flag[])
 
 	for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
 		if (fp_TRUE(flag[axis])) {
-			value[axis] = cm.offset[cm.gm.coord_system][axis] + _to_millimeters(origin[axis]);
+			value[axis] = _to_millimeters(origin[axis]);
 			cm.gmx.position[axis] = value[axis];		// set model position
 			cm.gm.target[axis] = value[axis];			// reset model target
 			mp_set_planner_position(axis, value[axis]);	// set mm position

--- a/firmware/tinyg/tinyg.h
+++ b/firmware/tinyg/tinyg.h
@@ -45,7 +45,7 @@
 /****** REVISIONS ******/
 
 #ifndef TINYG_FIRMWARE_BUILD
-#define TINYG_FIRMWARE_BUILD        440.14	// motor enable bounds checking; arc correction
+#define TINYG_FIRMWARE_BUILD        440.15	// motor enable bounds checking; arc correction
 
 #endif
 #define TINYG_FIRMWARE_VERSION		0.97					// firmware major version


### PR DESCRIPTION
Fixes issue #135  

Probe while in inch units returns incorrect results in intermediate sr: reports, in prb: report, and corrupts pos: for probed axis in both current coordinate system and absolute machine coordinate system. 

This change fixes all above. 

Tested on 25 Jun 2015

fb]  firmware build            440.14
[fv]  firmware version            0.97
[hp]  hardware platform           1.00
[hv]  hardware version            8.00
[id]  TinyG ID                    2U2971-YQH
