### PR TITLE
Feature / New G-code commands M114, M115 and M400 added

### DIFF
--- a/firmware/tinyg/canonical_machine.h
+++ b/firmware/tinyg/canonical_machine.h
@@ -125,6 +125,11 @@ typedef enum {				        // master queue flush state machine
     FLUSH_REQUESTED,                // flush has been requested but not started yet
 } cmQueueFlushState;
 
+typedef enum {				        // buffers drain state machine
+    DRAIN_OFF = 0,				    // no buffers drain in effect
+    DRAIN_REQUESTED,                // drain has not completed yet
+} cmBuffersDrainState;
+
 typedef enum {				        // applies to cm.homing_state
 	HOMING_NOT_HOMED = 0,			// machine is not homed (0=false)
 	HOMING_HOMED = 1,				// machine is homed (1=true)
@@ -162,7 +167,11 @@ typedef enum {						    // these are in order to optimized CASE statement
 	NEXT_ACTION_SUSPEND_ORIGIN_OFFSETS,	// G92.2
 	NEXT_ACTION_RESUME_ORIGIN_OFFSETS,	// G92.3
 	NEXT_ACTION_DWELL,					// G4
-	NEXT_ACTION_STRAIGHT_PROBE			// G38.2
+	NEXT_ACTION_STRAIGHT_PROBE,			// G38.2
+	NEXT_ACTION_GET_POSITION,			// M114
+	NEXT_ACTION_GET_FIRMWARE,			// M115
+	NEXT_ACTION_WAIT_FOR_COMPLETION		// M400
+
 } cmNextAction;
 
 typedef enum {						    // G Modal Group 1
@@ -535,6 +544,7 @@ typedef struct cmSingleton {                // struct to manage cm globals and c
     cmFeedholdState hold_state;             // hold: feedhold state machine
     cmOverrideState mfo_state;              // feed override state machine
     cmQueueFlushState queue_flush_state;    // master queue flush state machine
+    cmBuffersDrainState buffers_drain_state; // buffers drain state machine
 
     uint8_t safety_interlock_disengaged;    // set non-zero to start interlock processing (value is input number)
     uint8_t safety_interlock_reengaged;     // set non-zero to end interlock processing (value is input number)

--- a/firmware/tinyg/controller.c
+++ b/firmware/tinyg/controller.c
@@ -362,8 +362,19 @@ static stat_t _sync_to_tx_buffer()
 
 static stat_t _sync_to_planner()
 {
-	if (mp_get_planner_buffers_available() < PLANNER_BUFFER_HEADROOM) { // allow up to N planner buffers for this line
-		return (STAT_EAGAIN);
+	if (cm.buffers_drain_state == DRAIN_REQUESTED) {
+		if (mp_get_planner_buffers_available() < PLANNER_BUFFER_POOL_SIZE) { // need to drain it
+			return (STAT_EAGAIN);
+		}
+		else {
+			cm.buffers_drain_state = DRAIN_OFF;
+			return (STAT_COMPLETE);
+		}
+	}
+	else {
+		if (mp_get_planner_buffers_available() < PLANNER_BUFFER_HEADROOM) { // allow up to N planner buffers for this line
+			return (STAT_EAGAIN);
+		}
 	}
 	return (STAT_OK);
 }

--- a/firmware/tinyg/gcode_parser.c
+++ b/firmware/tinyg/gcode_parser.c
@@ -358,7 +358,7 @@ static stat_t _parse_gcode_block(char *buf)
 			break;
 
 			case 'M':
-			switch((uint8_t)value) {
+			switch((uint16_t)value) {
 				case 0: case 1: case 60:
 						SET_MODAL (MODAL_GROUP_M4, program_flow, PROGRAM_STOP);
 				case 2: case 30:
@@ -374,6 +374,9 @@ static stat_t _parse_gcode_block(char *buf)
 				case 49: SET_MODAL (MODAL_GROUP_M9, override_enables, false);
 				case 50: SET_MODAL (MODAL_GROUP_M9, feed_rate_override_enable, true); // conditionally true
 				case 51: SET_MODAL (MODAL_GROUP_M9, spindle_override_enable, true);	  // conditionally true
+				case 114: SET_NON_MODAL (next_action, NEXT_ACTION_GET_POSITION);
+				case 115: SET_NON_MODAL (next_action, NEXT_ACTION_GET_FIRMWARE);
+				case 400: SET_NON_MODAL (next_action, NEXT_ACTION_WAIT_FOR_COMPLETION);
 				default: status = STAT_MCODE_COMMAND_UNSUPPORTED;
 			}
 			break;
@@ -500,6 +503,30 @@ static stat_t _execute_gcode_block()
 		case NEXT_ACTION_RESET_ORIGIN_OFFSETS: { status = cm_reset_origin_offsets(); break;}
 		case NEXT_ACTION_SUSPEND_ORIGIN_OFFSETS: { status = cm_suspend_origin_offsets(); break;}
 		case NEXT_ACTION_RESUME_ORIGIN_OFFSETS: { status = cm_resume_origin_offsets(); break;}
+		case NEXT_ACTION_GET_POSITION: {
+				// M114: Get current position, see https://www.reprap.org/wiki/G-code#M114:_Get_Current_Position
+				size_t len = 0;
+				for (uint8_t axis = AXIS_X; axis < AXES; axis++) {
+					float position = cm.gm.target[axis] - cm_get_active_coord_offset(axis);
+					len += sprintf(global_string_buf + len, "%c:%0.4f ", "XYZABC"[axis], position);
+				}
+				// Replace last trailing space with newline.
+				global_string_buf[len-1] = '\n';
+				fprintf(stderr, global_string_buf);
+				break;
+			}
+		case NEXT_ACTION_GET_FIRMWARE: {
+				// M115: Get Firmware Version and Capabilities, see https://www.reprap.org/wiki/G-code#M115:_Get_Firmware_Version_and_Capabilities.
+				static const char m115_response[] PROGMEM = "FIRMWARE_NAME:TinyG, FIRMWARE_URL:https%%3A//github.com/synthetos/TinyG, FIRMWARE_VERSION:%0.2f\n";
+				fprintf_P(stderr, m115_response, TINYG_FIRMWARE_BUILD);
+				break;
+			}
+		case NEXT_ACTION_WAIT_FOR_COMPLETION: {
+				// M400: Wait for current moves to finish, see https://www.reprap.org/wiki/G-code#M400:_Wait_for_current_moves_to_finish
+				// Wait for all buffers to be drained, before accepting the next command.
+				cm.buffers_drain_state = DRAIN_REQUESTED; 
+				break;
+			}
 
 		case NEXT_ACTION_DEFAULT: {
 			cm_set_absolute_override(MODEL, cm.gn.absolute_override);	// apply override setting to gm struct

--- a/firmware/tinyg/stepper.c
+++ b/firmware/tinyg/stepper.c
@@ -1117,7 +1117,7 @@ void st_prep_dwell(float microseconds)
 {
 	st_pre.move_type = MOVE_TYPE_DWELL;
 	st_pre.dda_period = _f_to_period(FREQUENCY_DWELL);
-	st_pre.dda_ticks = (uint32_t)((microseconds/1000000) * FREQUENCY_DWELL);
+	st_pre.dda_ticks = (uint32_t)((microseconds/1000000) * FREQUENCY_DWELL + 1); // Make sure it is not zero by adding 1.
 	st_pre.buffer_state = PREP_BUFFER_OWNED_BY_LOADER;	// signal that prep buffer is ready
 }
 


### PR DESCRIPTION
**WARNING**: better use the master branch based #258. The `edge-0.98` branch is buggy. 

## Description
This Pull Request implements the common RS274/NGC/G-code commands M114, M115 and M400.

- `M114`: [Get current position](https://www.reprap.org/wiki/G-code#M114:_Get_Current_Position)
- `M115`: [Get Firmware Version and Capabilities](https://www.reprap.org/wiki/G-code#M115:_Get_Firmware_Version_and_Capabilities)
- `M400`: [Wait for current moves to finish](https://www.reprap.org/wiki/G-code#M400:_Wait_for_current_moves_to_finish)

As a "bonus", a little bug was removed: TinyG should not hang when the P word dwell time is zero.

`G4 P0`

## Justification
TinyG is quite common in [OpenPnP](https://openpnp.org/) usage, mostly because it is the stock controller for the [Liteplacer](https://www.liteplacer.com/) and users often adopt OpenPnP. 

### M115 Get Firmware Version and Capabilities
OpenPnP [is being extended](https://github.com/openpnp/openpnp/pull/1071) to assist users with more automatism when setting up the Gcode. The first step is automatically identifying the controller/firmware and for many controllers this is done with the **M115** code. Discovery is a chicken-and-egg problem: No controller specific commands can be used, before the controller model is known. TinyG having alternative means of identifying itself does not help in this case. 

Example:

`M115`

`FIRMWARE_NAME:TinyG, FIRMWARE_URL:https%3A//github.com/synthetos/TinyG, FIRMWARE_VERSION:444.23`

### M400 Wait for current moves to finish
OpenPnP often needs to interact with the machine. One example: The camera is moved to a location, then Computer Vision is used. Obviously, OpenPnP need to know when the camera is there, before it can take a picture.  

In TinyG, there is currently no (known) means to block until moves have finished. OpenPnP is instead polling for status reports, in order to know when a move is done. This only works when status reports are enabled, which generates unsolicited reports in the response stream, which in turn makes it hard to clearly associate responses with commands (race conditions cannot be strictly excluded). 

M400 now blocks all further command processing, until the move buffers have drained. This is done with the existing flow-control mechanism: Instead of waiting for the command buffers to not be full, it is waiting for them to be empty. 

Example:

`G1 X100`

`M400   ; wait for the move to complete`

`{sr:n}    ; only then execute the status report`

It is important to note that the command only affects processing when it is used. 

### M114 Get current position

To further unify the Gcode setup, the M114 code is also implemented. It reports the current target position in the common format.

Example:

`M114`

`X:100.0000 Y:0.0000 Z:0.0000 A:0.0000 B:0.0000 C:0.0000`

## Testing

The changes have been tested on a TinyG v8. 
