### PR TITLE
Fix faulty STAT_ARC_SPECIFICATION_ERROR

### DIFF
--- a/firmware/tinyg/plan_arc.c
+++ b/firmware/tinyg/plan_arc.c
@@ -260,7 +260,7 @@ static stat_t _compute_arc()
     float end_1 = arc.gm.target[arc.plane_axis_1] - arc.position[arc.plane_axis_1] - arc.offset[arc.plane_axis_1];
     float err = fabs(hypotf(end_0, end_1) - arc.radius);   // end radius - start radius
     if ( (err > ARC_RADIUS_ERROR_MAX) || 
-        ((err < ARC_RADIUS_ERROR_MIN) && 
+        ((err > ARC_RADIUS_ERROR_MIN) && 
          (err > arc.radius * ARC_RADIUS_TOLERANCE)) ) {
 //        return (STAT_ARC_HAS_IMPOSSIBLE_CENTER_POINT);
         return (STAT_ARC_SPECIFICATION_ERROR);


### PR DESCRIPTION
This test was in earlier versions in accordance with linuxcnc.org specification. In the latest version the smaller than sign switched to greater than, which was the cause of faulty error messages.